### PR TITLE
yapr.jpへ転送させる。

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# yaprj
+Webpage of Yapr LLC
+
+重要！！！！！！
+yapr.jp に移管しました。
+https://github.com/yapr/yapr.jp 管理はこちらでやっています。

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <title>ヤプル合同会社</title>
 <meta name="description" content="">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="refresh" content="0; URL=https://yapr.jp">
 <link href="./template_files/css/style.css%3F1583978598.css" rel="stylesheet">
 <link href="./template_files/css/npo.css%3F1583978598.css" rel="stylesheet">
 


### PR DESCRIPTION
## 
会社のアドレスを yaprj.com から yapr.jp へ変更したので転送をかける。
お名前.comで転送が有料だったので HTMLのリダイレクトにした。
対してアクセスがないのでよしとした。